### PR TITLE
Patch 1

### DIFF
--- a/R/taxonomy.R
+++ b/R/taxonomy.R
@@ -42,9 +42,8 @@ gi2taxid = function(gi){
 parse_LinkSet = function(LinkSet){
   gid = xpathSApply(LinkSet, './/IdList/Id', xmlValue)
   taxid = xpathSApply(LinkSet, './/LinkSetDb/Link/Id', xmlValue)
-  if(is.matrix(taxid)) {
+  if(length(taxid) > 1)
     taxid = NA
-  }
   if(length(taxid) == 0)
     taxid = NA
   names(taxid) = gid

--- a/R/taxonomy.R
+++ b/R/taxonomy.R
@@ -43,7 +43,7 @@ parse_LinkSet = function(LinkSet){
   gid = xpathSApply(LinkSet, './/IdList/Id', xmlValue)
   taxid = xpathSApply(LinkSet, './/LinkSetDb/Link/Id', xmlValue)
   if(is.matrix(taxid)) {
-    taxid = as.character(taxid[1,1])
+    taxid <- as.character(taxid[1,1])
   }
   if(length(taxid) == 0)
     taxid = NA

--- a/R/taxonomy.R
+++ b/R/taxonomy.R
@@ -42,7 +42,7 @@ gi2taxid = function(gi){
 parse_LinkSet = function(LinkSet){
   gid = xpathSApply(LinkSet, './/IdList/Id', xmlValue)
   taxid = xpathSApply(LinkSet, './/LinkSetDb/Link/Id', xmlValue)
-  if(is.matrix(taxid) {
+  if(is.matrix(taxid)) {
     taxid = taxid[1,2]
   }
   if(length(taxid) == 0)

--- a/R/taxonomy.R
+++ b/R/taxonomy.R
@@ -41,7 +41,10 @@ gi2taxid = function(gi){
 }
 parse_LinkSet = function(LinkSet){
   gid = xpathSApply(LinkSet, './/IdList/Id', xmlValue)
-  taxid = xpathSApply(LinkSet, './/LinkSetDb/Link/Id', xmlValue)[0]
+  taxid = xpathSApply(LinkSet, './/LinkSetDb/Link/Id', xmlValue)
+  if(is.matrix(taxid) {
+    taxid = taxid[1,2]
+  }
   if(length(taxid) == 0)
     taxid = NA
   names(taxid) = gid

--- a/R/taxonomy.R
+++ b/R/taxonomy.R
@@ -43,7 +43,7 @@ parse_LinkSet = function(LinkSet){
   gid = xpathSApply(LinkSet, './/IdList/Id', xmlValue)
   taxid = xpathSApply(LinkSet, './/LinkSetDb/Link/Id', xmlValue)
   if(is.matrix(taxid)) {
-    taxid <- as.character(taxid[1,1])
+    taxid = NA
   }
   if(length(taxid) == 0)
     taxid = NA

--- a/R/taxonomy.R
+++ b/R/taxonomy.R
@@ -43,7 +43,7 @@ parse_LinkSet = function(LinkSet){
   gid = xpathSApply(LinkSet, './/IdList/Id', xmlValue)
   taxid = xpathSApply(LinkSet, './/LinkSetDb/Link/Id', xmlValue)
   if(is.matrix(taxid)) {
-    taxid = as.list(taxid[1,])
+    taxid = as.character(taxid[1,1])
   }
   if(length(taxid) == 0)
     taxid = NA

--- a/R/taxonomy.R
+++ b/R/taxonomy.R
@@ -41,7 +41,7 @@ gi2taxid = function(gi){
 }
 parse_LinkSet = function(LinkSet){
   gid = xpathSApply(LinkSet, './/IdList/Id', xmlValue)
-  taxid = xpathSApply(LinkSet, './/LinkSetDb/Link/Id', xmlValue)
+  taxid = xpathSApply(LinkSet, './/LinkSetDb/Link/Id', xmlValue)[0]
   if(length(taxid) == 0)
     taxid = NA
   names(taxid) = gid

--- a/R/taxonomy.R
+++ b/R/taxonomy.R
@@ -43,7 +43,7 @@ parse_LinkSet = function(LinkSet){
   gid = xpathSApply(LinkSet, './/IdList/Id', xmlValue)
   taxid = xpathSApply(LinkSet, './/LinkSetDb/Link/Id', xmlValue)
   if(is.matrix(taxid)) {
-    taxid = taxid[1,2]
+    taxid = taxid[1,]
   }
   if(length(taxid) == 0)
     taxid = NA

--- a/R/taxonomy.R
+++ b/R/taxonomy.R
@@ -43,7 +43,7 @@ parse_LinkSet = function(LinkSet){
   gid = xpathSApply(LinkSet, './/IdList/Id', xmlValue)
   taxid = xpathSApply(LinkSet, './/LinkSetDb/Link/Id', xmlValue)
   if(is.matrix(taxid)) {
-    taxid = taxid[1,]
+    taxid = as.list(taxid[1,])
   }
   if(length(taxid) == 0)
     taxid = NA


### PR DESCRIPTION
This is a bit of a hack fix. The other fix didn't work. This just dumps any gi where there are two taxids on the webpage. The trick to getting these gis will be parsing the webpage so that you get the right one of the two GIs, otherwise you might get the host taxid.

Ok, I lied. This doesn't fix the issue. gi2taxid seems to work, but get_taxonomy still doesn't
